### PR TITLE
CyberRunner Replay Buffer Updates

### DIFF
--- a/dreamerv3/dreamerv3/embodied/replay/cyberrunner.py
+++ b/dreamerv3/dreamerv3/embodied/replay/cyberrunner.py
@@ -34,18 +34,18 @@ class Cyberrunner(generic.Generic):
             chunks=chunks,
         )
 
-    def add(self, step, worker=0, load=False):
+    def add(self, orig_step, worker=0, load=False):
         # Do transformations
         # print(step)
         # print(worker)
         i = 0
         if load:
-            super().add(step, str(i), load)
+            super().add(orig_step, str(i), load)
             return
         for dir in [0]:
             for flip_h in [0, 1]:
                 for flip_v in [0, 1]:
-                    step = step.copy()
+                    step = orig_step.copy()
                     image = step["image"].copy()
                     states = step["states"].copy()
                     goal = (

--- a/dreamerv3/dreamerv3/embodied/replay/cyberrunner.py
+++ b/dreamerv3/dreamerv3/embodied/replay/cyberrunner.py
@@ -38,10 +38,10 @@ class Cyberrunner(generic.Generic):
         # Do transformations
         # print(step)
         # print(worker)
-        i = 0
         if load:
-            super().add(orig_step, str(i), load)
+            super().add(orig_step, worker, load)
             return
+        i = 0
         for dir in [0]:
             for flip_h in [0, 1]:
                 for flip_v in [0, 1]:


### PR DESCRIPTION
While reviewing the experience data saved in the CyberRunner replay buffer, it came to my attention that the augmented data was not be added as intended. In each iteration of the nested for loop, the various data transformations were being applied sequentially to the same copy of the step dictionary, rather than being applied independently to the original step dictionary collected from the physical environment. This causes a horizontal-flip only version of the data to never be added, and a second duplicate copy of the original data to be added instead.